### PR TITLE
Fix lint errors

### DIFF
--- a/api/krusty/openapicustomschema_test.go
+++ b/api/krusty/openapicustomschema_test.go
@@ -650,7 +650,7 @@ func TestCustomOpenApiFieldWithoutMergePatchExtension(t *testing.T) {
 		t.Helper()
 		th := kusttest_test.MakeHarness(t)
 		writeTestSchema(th, "./")
-                th.WriteF("yetanothercrd_base.yaml", `
+		th.WriteF("yetanothercrd_base.yaml", `
 apiVersion: example.com/v1alpha1
 kind: MyCRD
 metadata:
@@ -663,7 +663,7 @@ spec:
     - name: bar
       value: bar
 `)
-                th.WriteF("yetanothercrd_patch.yaml", `
+		th.WriteF("yetanothercrd_patch.yaml", `
 apiVersion: example.com/v1alpha1
 kind: MyCRD
 metadata:
@@ -674,7 +674,7 @@ spec:
     - name: bar
       value: patched
 `)
-                th.WriteK(".", `
+		th.WriteK(".", `
 resources:
 - yetanothercrd_base.yaml
 openapi:
@@ -682,7 +682,7 @@ openapi:
 patches:
 - path: yetanothercrd_patch.yaml
 `)
-                m := th.Run(".", th.MakeDefaultOptions())
+		m := th.Run(".", th.MakeDefaultOptions())
 		th.AssertActualEqualsExpected(m, `
 apiVersion: example.com/v1alpha1
 kind: MyCRD
@@ -696,5 +696,5 @@ spec:
     - name: bar
       value: patched
 `)
-        })
+	})
 }

--- a/kyaml/openapi/example_test.go
+++ b/kyaml/openapi/example_test.go
@@ -47,7 +47,7 @@ func Example_arrayReplace() {
 	// Output:
 	// Arguments to the entrypoint. The docker image's CMD is used if this is...
 	// [array]
-        //  []
+	//  []
 }
 
 func Example_arrayElement() {

--- a/kyaml/yaml/schema/schema_test.go
+++ b/kyaml/yaml/schema/schema_test.go
@@ -49,9 +49,9 @@ func TestIsAssociativeMultipleStrategy(t *testing.T) {
 
 func TestIsAssociativeCrdList(t *testing.T) {
 	s := makeSchema()
-        // The value should be []interface{}, not []string
-        keys := make([]interface{}, 1)
-        keys[0] = "name"
+	// The value should be []interface{}, not []string
+	keys := make([]interface{}, 1)
+	keys[0] = "name"
 	s.Extensions["x-kubernetes-list-map-keys"] = keys
 	s.Extensions["x-kubernetes-list-type"] = "map"
 	assert.True(


### PR DESCRIPTION
IIRC, file save on emacs should run `go fmt` automatically. But as per the result of `go fmt`.
