### PR TITLE
Fix TestCustomOpenApiFieldWithoutMergePatchExtension

### DIFF
--- a/api/krusty/openapicustomschema_test.go
+++ b/api/krusty/openapicustomschema_test.go
@@ -691,10 +691,10 @@ metadata:
 spec:
   custom:
     objects:
-    - name: foo
-      value: foo
     - name: bar
       value: patched
+    - name: foo
+      value: foo
 `)
 	})
 }


### PR DESCRIPTION
Expected result in `TestCustomOpenApiFieldWithoutMergePatchExtension` relied on https://github.com/tsekine354/kustomize/pull/6. It shouldn't.

That test case will be revised in the PR.
