### PR TITLE
Fix: Reset OpenAPI state in test harness for test isolation

### DIFF
--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/ifc"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
 	fLdr "sigs.k8s.io/kustomize/api/internal/loader"
 	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/konfig"
@@ -103,6 +104,7 @@ func (th *HarnessEnhanced) MkDir(path string) string {
 }
 
 func (th *HarnessEnhanced) Reset() {
+	openapi.ResetOpenAPI()
 	if th.shouldWipeLdrRoot {
 		root, _ := filepath.EvalSymlinks(th.ldr.Root())
 		tmpdir, _ := filepath.EvalSymlinks(os.TempDir())


### PR DESCRIPTION
The test TestPatchDeleteOfNotExistingAttributesShouldNotAddExtraElements in api/krusty/patchdelete_test.go was observed to fail when run as part of a larger test suite (e.g., `cd api; go test -v ./krusty`) but would pass when run individually. This indicated that global state related to kyaml/openapi was leaking between tests.

If a preceding test modified the global OpenAPI schema state (e.g., by suppressing the built-in schema via SuppressBuiltInSchemaUse(), or by loading a specific custom schema) and did not clean it up, subsequent tests could fail if they relied on the default schema loading behavior. The target test requires the default schema to correctly determine list merge strategies for strategic merge patches.

This commit modifies the `Reset()` method in
`api/testutils/kusttest/HarnessEnhanced` to include a call to `openapi.ResetOpenAPI()`. This function clears any previously loaded custom schemas, resets the Kubernetes OpenAPI version, and ensures flags like `noUseBuiltInSchema` are returned to their default false state.

By ensuring that the global OpenAPI schema state is reset for each test using this harness, this change improves test isolation and prevents state leakage, allowing tests like
TestPatchDeleteOfNotExistingAttributesShouldNotAddExtraElements to reliably pass within a suite.