### PR TITLE
Fix: Ensure OpenAPI state is reset for HarnessEnhanced tests

### DIFF
--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -12,6 +12,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	fLdr "sigs.k8s.io/kustomize/api/internal/loader"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
 	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/provider"
@@ -47,6 +48,7 @@ type HarnessEnhanced struct {
 
 func MakeEnhancedHarness(t *testing.T) *HarnessEnhanced {
 	t.Helper()
+	openapi.ResetOpenAPI()
 	r := makeBaseEnhancedHarness(t)
 	r.Harness = MakeHarnessWithFs(t, filesys.MakeFsInMemory())
 	// Point the Harness's file loader to the root ('/')
@@ -103,6 +105,7 @@ func (th *HarnessEnhanced) MkDir(path string) string {
 }
 
 func (th *HarnessEnhanced) Reset() {
+	openapi.ResetOpenAPI()
 	if th.shouldWipeLdrRoot {
 		root, _ := filepath.EvalSymlinks(th.ldr.Root())
 		tmpdir, _ := filepath.EvalSymlinks(os.TempDir())


### PR DESCRIPTION
The test TestPatchDeleteOfNotExistingAttributesShouldNotAddExtraElements in api/krusty/patchdelete_test.go was failing when run as part of the api/krusty package tests, but passed when run individually. This indicated that global state from kyaml/openapi was leaking between tests, specifically the `noUseBuiltInSchema` flag or other schema configurations.

This commit addresses the issue by:
1. Calling `openapi.ResetOpenAPI()` at the beginning of the `MakeEnhancedHarness` function in `api/testutils/kusttest/harnessenhanced.go`. This ensures that each test using this harness starts with a clean OpenAPI slate, preventing interference from previously run tests.
2. Ensuring `openapi.ResetOpenAPI()` is also called in the `Reset()` method of `HarnessEnhanced`. This cleans up any OpenAPI state modified by the current test, protecting subsequent tests and providing defense in depth.

This approach ensures that the built-in OpenAPI schema is correctly loaded for tests that rely on it, resolving the failure in TestPatchDeleteOfNotExistingAttributesShouldNotAddExtraElements.